### PR TITLE
feat: experiment deep query decomposition

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -310,7 +310,7 @@ export async function getResponse(question?: string,
       evaluationMetrics[currentQuestion].push('strict')
     }
 
-    if (step === 1) {
+    if (step === 1 && evaluationMetrics[currentQuestion].includes('freshness')) {
       // if it detects freshness, avoid direct answer at step 1
       allowAnswer = false;
       allowReflect = false;

--- a/src/tools/query-rewriter.ts
+++ b/src/tools/query-rewriter.ts
@@ -201,6 +201,7 @@ export async function rewriteQuery(action: SearchAction, trackers: TrackerContex
 
 export async function rewriteQueryDeep(action: SearchAction, trackers: TrackerContext, schemaGen: Schemas): Promise<{ queries: string[] }> {
   try {
+    console.log('call deep rewrite')
     const generator = new ObjectGeneratorSafe(trackers.tokenTracker);
     const allQueries = [...action.searchRequests];
     const motivationExplanation = `\
@@ -213,7 +214,7 @@ However, we can brainstorm possible motivations.
 Given the following search queries:
 ${JSON.stringify(allQueries, null, 2)}
 
-Brainstorm the top 5 most unlikely unique possible motivations (out of 100) why the user is typing these queries into a search engine.
+Brainstorm the top 5 most likely unique possible motivations (out of 100) why the user is typing these queries into a search engine.
 Note: All possible motivations are 100% distinct from each other and must give a very different explanation.
 Most importantly, each motivation must not be predictable.`
 
@@ -241,6 +242,7 @@ Your task is to generate a very specific version of the search query for each mo
     });
     trackers?.actionTracker.trackThink(searchQueriesResult.object.think);
     const queries = searchQueriesResult.object.queries;
+    console.log('here are the queries', queries)
     return {queries};
   } catch (error) {
     console.error(`Error in ${TOOL_NAME}`, error);

--- a/src/tools/query-rewriter.ts
+++ b/src/tools/query-rewriter.ts
@@ -214,7 +214,7 @@ However, we can brainstorm possible motivations.
 Given the following search queries:
 ${JSON.stringify(allQueries, null, 2)}
 
-Brainstorm the top 5 most likely unique possible motivations (out of 100) why the user is typing these queries into a search engine.
+Brainstorm the top 10 most unlikely unique possible motivations (out of 100) why the user is typing these queries into a search engine.
 Note: All possible motivations are 100% distinct from each other and must give a very different explanation.
 Most importantly, each motivation must not be predictable.`
 

--- a/src/tools/query-rewriter.ts
+++ b/src/tools/query-rewriter.ts
@@ -177,7 +177,6 @@ export async function rewriteQuery(action: SearchAction, trackers: TrackerContex
     const generator = new ObjectGeneratorSafe(trackers.tokenTracker);
     const allQueries = [...action.searchRequests];
 
-    throw new Error(`allAction: ${JSON.stringify(action)}, allQueries: ${JSON.stringify(allQueries)}`);
     const queryPromises = action.searchRequests.map(async (req) => {
       const prompt = getPrompt(req, action.think);
       const result = await generator.generateObject({
@@ -193,7 +192,6 @@ export async function rewriteQuery(action: SearchAction, trackers: TrackerContex
     const queryResults = await Promise.all(queryPromises);
     queryResults.forEach(queries => allQueries.push(...queries));
     console.log(TOOL_NAME, allQueries);
-
     return {queries: allQueries};
   } catch (error) {
     console.error(`Error in ${TOOL_NAME}`, error);

--- a/src/tools/query-rewriter.ts
+++ b/src/tools/query-rewriter.ts
@@ -2,6 +2,7 @@ import {PromptPair, SearchAction, TrackerContext} from '../types';
 import {ObjectGeneratorSafe} from "../utils/safe-generator";
 import {Schemas} from "../utils/schemas";
 
+export const IS_DEEP_QUERY_REWRITE = true
 
 function getPrompt(query: string, think: string): PromptPair {
   const currentTime = new Date();
@@ -171,36 +172,36 @@ ${query}
 
 const TOOL_NAME = 'queryRewriter';
 
-// export async function rewriteQuery(action: SearchAction, trackers: TrackerContext, schemaGen: Schemas): Promise<{ queries: string[] }> {
-//   try {
-//     const generator = new ObjectGeneratorSafe(trackers.tokenTracker);
-//     const allQueries = [...action.searchRequests];
-//
-//     throw new Error(`allAction: ${JSON.stringify(action)}, allQueries: ${JSON.stringify(allQueries)}`);
-//     const queryPromises = action.searchRequests.map(async (req) => {
-//       const prompt = getPrompt(req, action.think);
-//       const result = await generator.generateObject({
-//         model: TOOL_NAME,
-//         schema: schemaGen.getQueryRewriterSchema(),
-//         system: prompt.system,
-//         prompt: prompt.user,
-//       });
-//       trackers?.actionTracker.trackThink(result.object.think);
-//       return result.object.queries;
-//     });
-//
-//     const queryResults = await Promise.all(queryPromises);
-//     queryResults.forEach(queries => allQueries.push(...queries));
-//     console.log(TOOL_NAME, allQueries);
-//
-//     return {queries: allQueries};
-//   } catch (error) {
-//     console.error(`Error in ${TOOL_NAME}`, error);
-//     throw error;
-//   }
-// }
-
 export async function rewriteQuery(action: SearchAction, trackers: TrackerContext, schemaGen: Schemas): Promise<{ queries: string[] }> {
+  try {
+    const generator = new ObjectGeneratorSafe(trackers.tokenTracker);
+    const allQueries = [...action.searchRequests];
+
+    throw new Error(`allAction: ${JSON.stringify(action)}, allQueries: ${JSON.stringify(allQueries)}`);
+    const queryPromises = action.searchRequests.map(async (req) => {
+      const prompt = getPrompt(req, action.think);
+      const result = await generator.generateObject({
+        model: TOOL_NAME,
+        schema: schemaGen.getQueryRewriterSchema(),
+        system: prompt.system,
+        prompt: prompt.user,
+      });
+      trackers?.actionTracker.trackThink(result.object.think);
+      return result.object.queries;
+    });
+
+    const queryResults = await Promise.all(queryPromises);
+    queryResults.forEach(queries => allQueries.push(...queries));
+    console.log(TOOL_NAME, allQueries);
+
+    return {queries: allQueries};
+  } catch (error) {
+    console.error(`Error in ${TOOL_NAME}`, error);
+    throw error;
+  }
+}
+
+export async function rewriteQueryDeep(action: SearchAction, trackers: TrackerContext, schemaGen: Schemas): Promise<{ queries: string[] }> {
   try {
     const generator = new ObjectGeneratorSafe(trackers.tokenTracker);
     const allQueries = [...action.searchRequests];

--- a/src/utils/schemas.ts
+++ b/src/utils/schemas.ts
@@ -127,6 +127,16 @@ export class Schemas {
     });
   }
 
+  getMotivationsSchema(): z.ZodObject<any> {
+    return z.object({
+      think: z.string().describe(`Explain why you choose those underlying motivations. ${this.getLanguagePrompt()}`).max(500),
+      motivations: z.array(z.string().describe('actual motivation for the search query, one sentence'))
+        .min(1)
+        .max(MAX_QUERIES_PER_STEP)
+        .describe(`'Array of unique motivations, all motivations are orthogonal to each other. Maximum ${MAX_QUERIES_PER_STEP} motivations allowed.'`)
+    });
+  }
+
   getEvaluatorSchema(evalType: EvaluationType): z.ZodObject<any> {
     const baseSchema = {
       pass: z.boolean().describe('Whether the answer passes the evaluation criteria defined by the evaluator'),


### PR DESCRIPTION
Experiment on query decomposition.
The decomposition works in two steps.
1. A list of possible underlying motivations is created
2. Based on each possible motivation a search query is generated

This appraoch plays with the ambiguity of search queries.
Since search queries are short and therefore underspecified by nature, each search query can be assigned to a set of possible motivations that lead to that query.
After generating all motivations, a new query can be conducted for all the motivations.