### PR TITLE
fix: judging too fast

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -310,8 +310,8 @@ export async function getResponse(question?: string,
       evaluationMetrics[currentQuestion].push('strict')
     }
 
-    if (step === 1 && evaluationMetrics[currentQuestion].includes('freshness')) {
-      // if it detects freshness, avoid direct answer at step 1
+    if (step === 1) {
+      // always avoid direct answer at step 1
       allowAnswer = false;
       allowReflect = false;
     }


### PR DESCRIPTION
Query from michael: `npm run dev "How to configure a timeout when loading a huggingface dataset with python?"`
Before it halucinated a timeout parameter that did not exist.

This is the new response:
```
Final Answer: Configuring a timeout for loading Hugging Face datasets involves setting the timeout parameter within the `requests` library, which `datasets` uses for downloading. While there isn't a direct `timeout` parameter in `load_dataset`, you can configure the timeout globally for all `requests` calls or by patching the `fsspec` library that `datasets` uses.

1.  **Global Timeout Configuration (Not Recommended):**
You can configure the timeout globally using environment variables, but this affects all `requests` calls, which might not be desirable.

2.  **Patching `fsspec` (Recommended):**
`datasets` uses `fsspec` for file system operations, including downloads. You can patch `fsspec` to include a timeout parameter.

   ```python
   import fsspec
   from datasets import load_dataset

   def monkeypatch_http_timeout(timeout=120):
       original_http = fsspec.get_filesystem_class('http')
       original_https = fsspec.get_filesystem_class('https')

       class PatchedHTTPFileSystem(original_http):
           def __init__(self, *args, **kwargs):
               kwargs['timeout'] = timeout  # Set the timeout here
               super().__init__(*args, **kwargs)

       class PatchedHTTPSFileSystem(original_https):
           def __init__(self, *args, **kwargs):
               kwargs['timeout'] = timeout  # Set the timeout here
               super().__init__(*args, **kwargs)

       fsspec.register_implementation('http', PatchedHTTPFileSystem, clobber=True)
       fsspec.register_implementation('https', PatchedHTTPSFileSystem, clobber=True)

   monkeypatch_http_timeout(timeout=300)  # Set timeout to 300 seconds

   ds = load_dataset('HuggingFaceM4/VQAv2', split='train[:10%]')
   ```

   This code snippet patches the `fsspec` HTTP and HTTPS file system classes to include a `timeout` parameter in their `__init__` methods. This ensures that when `datasets` uses `fsspec` to download files, the specified timeout is applied.

3.  **Using `DownloadConfig` for Retries:**
    While not directly a timeout, you can use `DownloadConfig` to set the number of retries, which can help with transient network issues[^1].

    ```python
    from datasets import load_dataset, DownloadConfig

    download_config = DownloadConfig(retries=10)
    ds = load_dataset('HuggingFaceM4/VQAv2', split='train[:10%]', download_config=download_config)
    ```

It's important to note that extremely long timeouts might not always solve the problem, especially if the issue lies with the server or network connectivity. In such cases, consider downloading the dataset manually via the browser and then loading it from a local path.

```