### PR TITLE
fix: adjust prompt for serp cluster tool to avoid parse errors

### DIFF
--- a/src/tools/serp-cluster.ts
+++ b/src/tools/serp-cluster.ts
@@ -9,7 +9,7 @@ function getPrompt(results: SearchSnippet[]): PromptPair {
     system: `
 You are a search engine result analyzer. You look at the SERP API response and group them into meaningful cluster. 
 
-Each cluster should contain a summary of the content, key data and insights, the corresponding URLs and search advice. Respond in JSON format.
+Each cluster should contain a summary of the content, key data and insights, the corresponding URLs and search advice.
 `,
     user:
       `


### PR DESCRIPTION
### issue 

prompt in the serp cluster doesn't go well with gemini models ( 2.5-flash tested) and causes to output invalid JSON because it includes ```json``` syntax. Removing "Respond in JSON" fixes the issue

### how to reproduce

Prompt which causes the JSON parse issue. 

https://aistudio.google.com/app/prompts?state=%7B%22ids%22:%5B%221vNeDyEpCwLcad4knh-ROHgxseiNJOInC%22%5D,%22action%22:%22open%22,%22userId%22:%22117685563781048697479%22,%22resourceKeys%22:%7B%7D%7D&usp=sharing
